### PR TITLE
Add `no-throw-literal` rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ module.exports = {
         'no-mixed-spaces-and-tabs': 'error',
         'no-multi-assign': 'error',
         'no-nested-ternary': 'error',
+        'no-throw-literal': 'error',
         'no-trailing-spaces': 'error',
         'no-whitespace-before-property': 'error',
         'quote-props': ['error', 'as-needed', { keywords: false, unnecessary: true, numbers: false }],


### PR DESCRIPTION
> Disallow throwing literals as exceptions
>
> It is considered good practice to only throw the Error object itself or an object using the Error object as base objects for user-defined exceptions. The fundamental benefit of Error objects is that they automatically keep track of where they were built and originated."

https://eslint.org/docs/latest/rules/no-throw-literal